### PR TITLE
Fix potential unused parameter warnings

### DIFF
--- a/external/anyode/include/anyode/anyode_blasless.hpp
+++ b/external/anyode/include/anyode/anyode_blasless.hpp
@@ -61,7 +61,8 @@ namespace AnyODE {
         void operator()(const char * trans, const int * n, const int * nrhs, Real_t * a,
                         const int * lda, int * ipiv, Real_t * b, const int * ldb, int * info,
                         int sundials__=0) const noexcept {
-
+            ignore(trans);
+            ignore(sundials__);
             *info = 0;
             if (*n < 0)  *info = -1;
             if (*nrhs < 0)  *info = -2;
@@ -93,9 +94,12 @@ namespace AnyODE {
 
     template <typename Real_t = double> struct gemv_callback {
         void operator()(const char* trans, int * m, int * n, const Real_t * alpha,
-                        Real_t * a, int* lda, const Real_t * x, int * incx,
-                        const Real_t * beta, Real_t * y, int* incy, int sundials__=0) const noexcept {
-            std::function<Real_t& (const int, const int)> A;
+                        Real_t * a, int * lda, const Real_t * x, int * incx,
+                        const Real_t * beta, Real_t * y, int * incy, int sundials__=0) const noexcept {
+            ignore(incx);
+            ignore(incy);
+            ignore(sundials__);
+            td::function<Real_t& (const int, const int)> A;
             if (*trans == 'T')
                 A = [&](const int ri, const int ci) -> Real_t& { return a[ri*(*lda) + ci]; };
             else

--- a/external/anyode/include/anyode/anyode_blasless.hpp
+++ b/external/anyode/include/anyode/anyode_blasless.hpp
@@ -99,7 +99,7 @@ namespace AnyODE {
             ignore(incx);
             ignore(incy);
             ignore(sundials__);
-            td::function<Real_t& (const int, const int)> A;
+            std::function<Real_t& (const int, const int)> A;
             if (*trans == 'T')
                 A = [&](const int ri, const int ci) -> Real_t& { return a[ri*(*lda) + ci]; };
             else

--- a/pycvodes/include/cvodes_anyode_parallel.hpp
+++ b/pycvodes/include/cvodes_anyode_parallel.hpp
@@ -37,6 +37,7 @@ namespace cvodes_anyode_parallel {
                    bool with_jtimes=false
                    ){
         const int ny = odesys[0]->get_ny();
+        ignore(ny);
         const int nsys = odesys.size();
         auto results = std::vector<std::pair<int, std::vector<int>>>(nsys);
         anyode_parallel::ThreadException te;

--- a/pycvodes/include/cvodes_anyode_parallel.hpp
+++ b/pycvodes/include/cvodes_anyode_parallel.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdlib>
+#include "anyode/anyode.hpp"
 #include "anyode/anyode_parallel.hpp"
 #include "cvodes_anyode.hpp"
 
@@ -37,7 +38,7 @@ namespace cvodes_anyode_parallel {
                    bool with_jtimes=false
                    ){
         const int ny = odesys[0]->get_ny();
-        ignore(ny);
+        AnyODE::ignore(ny);
         const int nsys = odesys.size();
         auto results = std::vector<std::pair<int, std::vector<int>>>(nsys);
         anyode_parallel::ThreadException te;


### PR DESCRIPTION
Some unused parameters in the new BLAS-less implementations of BLAS routines, as well as one in the existing cvodes_anyode headers.