### PR TITLE
Bugfix

### DIFF
--- a/pycvodes/include/cvodes_cxx.hpp
+++ b/pycvodes/include/cvodes_cxx.hpp
@@ -1017,7 +1017,6 @@ public:
                  int tidx=0,
                  realtype ** ew_ele=nullptr // length(ew_ele) must be == 2*td*ny if not nullptr
         ){
-        realtype cur_t;
         int status;
         SVector y {ny};
         SVector yQ {nq};
@@ -1037,6 +1036,7 @@ public:
                 (*ew_ele)[tidx*2*ny+i] = 0.0;
             }
         }
+        realtype cur_t = xout(tidx);
         if (mxsteps == 0) { mxsteps = 500; } // cvodes default (MXSTEP_DEFAULT)
         if (record_steps)
             steps_seen.push_back(get_current_step());
@@ -1113,7 +1113,7 @@ public:
                                 ew = N_VNew_Serial(ny);
                                 get_est_local_errors(ele);
                                 get_err_weights(ew);
-                                double mx = 0.0;
+                                realtype mx = 0.0;
                                 int mxi = -1;
                                 for (unsigned i=0; i < ny; ++i){
                                     const realtype cur = NV_DATA_S(ele)[i]*NV_DATA_S(ew)[i];


### PR DESCRIPTION
This fixes a bug that only exposed itself when i) using extended precision and ii) running the `test_NativeSys__get_dx_max_source_code` test within pyodesys. It appears that `cur_t` is uninitialized in the adaptive integrator before being used in `get_dx_max` for the first time, which can result in undefined (in this case `nan`) output if the expression in `get_dx_max` involves the independent variable.