### PR TITLE
Set max steps between jac

### DIFF
--- a/pycvodes/__init__.py
+++ b/pycvodes/__init__.py
@@ -120,6 +120,9 @@ def integrate_adaptive(rhs, jac, y0, x0, xend, atol, rtol, dx0=.0,
             Whether to return error_weights, estimated_local_errors in info dict.
         'constraints': array
             Per component constraints 0.0: no constraint, 1.0: >=0, -1.0: <=0, 2.0: >0.0, -2.0: <0.0.
+        'max_steps_between_jac': int
+             Maximum  number  of  timesteps to wait before recomputation of the Jacobian or
+             recommendation to update the preconditioner.
 
     Returns
     -------

--- a/pycvodes/_cvodes.pyx
+++ b/pycvodes/_cvodes.pyx
@@ -83,7 +83,7 @@ def adaptive(rhs, jac, floating [:] yq0, floating x0, floating xend, atol,
              int autorestart=0, bool return_on_error=False, bool record_rhs_xvals=False,
              bool record_jac_xvals=False, bool record_order=False, bool record_fpe=False,
              bool record_steps=False, dx0cb=None, dx_max_cb=None, bool autonomous_exprs=False,
-             int nprealloc=500, jtimes=None, bool ew_ele=False, indextype nnz=-1, vector[realtype] constraints=[]):
+             int nprealloc=500, jtimes=None, bool ew_ele=False, indextype nnz=-1, vector[realtype] constraints=[], long int max_steps_between_jac=0):
     cdef:
         indextype nyq = yq0.shape[yq0.ndim - 1]
         indextype ny = nyq - nquads
@@ -151,7 +151,7 @@ def adaptive(rhs, jac, floating [:] yq0, floating x0, floating xend, atol,
             iter_type_from_name(iter_type.lower().encode('UTF-8')),
             linear_solver_from_name(linear_solver.lower().encode('UTF-8')),
             maxl, eps_lin, nderiv, return_on_root, autorestart, return_on_error, with_jtimes,
-            tidx, &ew_ele_out if ew_ele else NULL, constraints)
+            tidx, &ew_ele_out if ew_ele else NULL, constraints, max_steps_between_jac)
 
         xyqout_dims[0] = nout + 1
         xyqout_dims[1] = ny*(nderiv+1) + 1 + nquads
@@ -198,7 +198,8 @@ def predefined(rhs, jac,
                int autorestart=0, bool return_on_error=False, bool record_rhs_xvals=False,
                bool record_jac_xvals=False, bool record_order=False, bool record_fpe=False,
                bool record_steps=False, dx0cb=None, dx_max_cb=None, bool autonomous_exprs=False,
-               jtimes=None, bool ew_ele=False, indextype nnz=-1, const vector[realtype] constraints=[]):
+               jtimes=None, bool ew_ele=False, indextype nnz=-1, const vector[realtype] constraints=[],
+                   long int max_steps_between_jac=0):
     cdef:
         indextype nyq = yq0.shape[yq0.ndim - 1]
         indextype ny = nyq - nquads
@@ -260,7 +261,7 @@ def predefined(rhs, jac,
             dx0, dx_min, dx_max, with_jacobian, iter_type_from_name(iter_type.lower().encode('UTF-8')),
             linear_solver_from_name(linear_solver.lower().encode('UTF-8')),
             maxl, eps_lin, nderiv, autorestart, return_on_error, with_jtimes,
-            ew_ele_out if ew_ele else NULL, constraints)
+            ew_ele_out if ew_ele else NULL, constraints, max_steps_between_jac)
 
         yqout_dims[0] = xout.size
         yqout_dims[1] = nderiv + 1

--- a/pycvodes/include/cvodes_anyode.pxd
+++ b/pycvodes/include/cvodes_anyode.pxd
@@ -32,7 +32,8 @@ cdef extern from "cvodes_anyode.hpp" namespace "cvodes_anyode":
         const bool,
         int,
         realtype **,
-        vector[double]&
+        vector[double]&,
+        long int
     ) except +
 
     cdef int simple_predefined[U](
@@ -60,5 +61,6 @@ cdef extern from "cvodes_anyode.hpp" namespace "cvodes_anyode":
         const bool,
         const bool,
         realtype *,
-	vector[double]&
+        vector[double]&,
+        long int
     ) except +

--- a/pycvodes/include/cvodes_anyode_parallel.hpp
+++ b/pycvodes/include/cvodes_anyode_parallel.hpp
@@ -38,7 +38,8 @@ namespace cvodes_anyode_parallel {
                    const bool with_jtimes=false,
                    int tidx=0,
                    realtype ** ew_ele=nullptr,
-                   const std::vector<realtype> &constraints={}
+                   const std::vector<realtype> &constraints={},
+                   const long int msbj=0
                    ){
         const indextype ny = odesys[0]->get_ny();
         AnyODE::ignore(ny);
@@ -57,7 +58,7 @@ namespace cvodes_anyode_parallel {
                     odesys[idx], atol, rtol, lmm, tend[idx],
                     results[idx].second, mxsteps, dx0[idx], dx_min[idx], dx_max[idx],
                     with_jacobian, iter_type, linear_solver, maxl, eps_lin, nderiv,
-                    return_on_root, autorestart, return_on_error, with_jtimes, tidx, (ew_ele) ? &ew_ele[idx] : nullptr, constraints);
+                    return_on_root, autorestart, return_on_error, with_jtimes, tidx, (ew_ele) ? &ew_ele[idx] : nullptr, constraints, msbj);
             });
         }
         te.rethrow();
@@ -88,7 +89,8 @@ namespace cvodes_anyode_parallel {
                      const bool return_on_error=false,
                      const bool with_jtimes=false,
                      realtype ** ew_ele=nullptr,
-                     const std::vector<realtype> &constraints={}
+                     const std::vector<realtype> &constraints={},
+                     const long int msbj=0
                      ){
         const indextype ny = odesys[0]->get_ny();
         const int nsys = odesys.size();
@@ -110,7 +112,7 @@ namespace cvodes_anyode_parallel {
                         nreached_roots[idx].second.first, nreached_roots[idx].second.second,
                         mxsteps, dx0[idx], dx_min[idx], dx_max[idx], with_jacobian,
                         iter_type, linear_solver, maxl, eps_lin, nderiv,
-                        autorestart, return_on_error, with_jtimes, (ew_ele) ? ew_ele[idx] : nullptr, constraints);
+                        autorestart, return_on_error, with_jtimes, (ew_ele) ? ew_ele[idx] : nullptr, constraints, msbj);
             });
         }
         if (!return_on_error)

--- a/pycvodes/include/cvodes_anyode_parallel.pxd
+++ b/pycvodes/include/cvodes_anyode_parallel.pxd
@@ -31,7 +31,8 @@ cdef extern from "cvodes_anyode_parallel.hpp" namespace "cvodes_anyode_parallel"
         const bool,
         int,
         realtype**,
-        vector[realtype]&
+        vector[realtype]&,
+        long int
     ) except +
 
     cdef vector[pair[int, pair[vector[int], vector[realtype]]]] multi_predefined[U](
@@ -57,5 +58,6 @@ cdef extern from "cvodes_anyode_parallel.hpp" namespace "cvodes_anyode_parallel"
         const bool,
         const bool,
         realtype **,
-        vector[realtype]&
+        vector[realtype]&,
+        long int
     ) except +

--- a/pycvodes/include/cvodes_cxx.hpp
+++ b/pycvodes/include/cvodes_cxx.hpp
@@ -448,7 +448,6 @@ public:
     long int get_max_num_steps(){
         return this->mxsteps_;
     }
-
     // set_tol
     void set_tol(realtype rtol, realtype atol){
         int status = CVodeSStolerances(this->mem, rtol, atol);
@@ -798,8 +797,9 @@ public:
         case CVLS_LMEM_NULL:
             throw std::runtime_error("linear solver has not been initialized)");
         }
-        if ((check_ill_input) && (flag == CVLS_ILL_INPUT))
+        if ((check_ill_input) && (flag == CVLS_ILL_INPUT)) {
             throw std::runtime_error("Bad input.");
+        }
     }
     void set_jtimes_fn(CVSpilsJacTimesVecFn jtimes){
 #if SUNDIALS_VERSION_MAJOR >= 3
@@ -876,6 +876,17 @@ public:
 #endif
         this->cvspils_check_flag(flag);
     }
+// Linear solver options:
+    void set_max_steps_between_jac(long int msbj) {
+#if SUNDIALS_VERSION_MAJOR >= 4
+        int flag = CVodeSetMaxStepsBetweenJac(this->mem, msbj);
+        cvspils_check_flag(flag);
+#else
+        ignore(msbj);
+        throw std::runtime_error("set_max_steps_between_jac  requires sundials >=4.0.0");
+#endif
+    }
+// Getters:
     int get_current_order() {
         int qcur;
         CVodeGetCurrentOrder(this->mem, &qcur);


### PR DESCRIPTION
This is new in sundials 4

(passing all these settings as arguments to the C++ functions is still a terrible idea, but I'll defer fixing that for a future "pycvodes2" or something).